### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ktnyt/moji"
+	"github.com/ktnyt/go-moji"
 )
 
 func main() {


### PR DESCRIPTION
The import statement within the example code was written as `github.com/ktnyt/moji`. Fixed to `github.com/ktnyt/go-moji`.